### PR TITLE
Patch whitespace on naming exercise updates

### DIFF
--- a/exercises/01_base_code/precipitation_climatology.py
+++ b/exercises/01_base_code/precipitation_climatology.py
@@ -65,7 +65,6 @@ def plot_zonal(data):
 
 
 def get_country_ann_avg(data, countries):
-
     data_avg = data['pr'].groupby('time.year').mean('time', keep_attrs=True)
     data_avg = convert_pr_units(data_avg)
 
@@ -113,7 +112,6 @@ def get_country_ann_avg(data, countries):
 
 
 def plot_enso(data):
-
     enso = data['pr'].sel(lat=slice(-1, 1)).sel(lon=slice(120, 280)).mean(dim="lat", keep_attrs=True)
     # print(enso)
     # .groupby('time.year').mean('time', keep_attrs=True)
@@ -238,7 +236,6 @@ def main(pr_file, season="DJF", output_file="output.png", gridlines=False, mask=
     plt.savefig(output_file, dpi=200)  # Save figure to file
 
 if __name__ == '__main__':
-
     input_file = "../../data/pr_Amon_ACCESS-ESM1-5_historical_r1i1p1f1_gn_201001-201412.nc"
     # season_to_plot = "DJF"
     # season_to_plot = "MAM"

--- a/exercises/02_formatting/precipitation_climatology.py
+++ b/exercises/02_formatting/precipitation_climatology.py
@@ -65,7 +65,6 @@ def plot_zonal(data):
 
 
 def get_country_ann_avg(data, countries):
-
     data_avg = data['pr'].groupby('time.year').mean('time', keep_attrs=True)
     data_avg = convert_pr_units(data_avg)
 
@@ -113,7 +112,6 @@ def get_country_ann_avg(data, countries):
 
 
 def plot_enso(data):
-
     enso = data['pr'].sel(lat=slice(-1, 1)).sel(lon=slice(120, 280)).mean(dim="lat", keep_attrs=True)
     # print(enso)
     # .groupby('time.year').mean('time', keep_attrs=True)
@@ -238,7 +236,6 @@ def main(pr_file, season="DJF", output_file="output.png", gridlines=False, mask=
     plt.savefig(output_file, dpi=200)  # Save figure to file
 
 if __name__ == '__main__':
-
     input_file = "../../data/pr_Amon_ACCESS-ESM1-5_historical_r1i1p1f1_gn_201001-201412.nc"
     # season_to_plot = "DJF"
     # season_to_plot = "MAM"


### PR DESCRIPTION
Update exercises 1 and 2 with blank lines to match changes to later exercises (blank lines not picked up by black).

I think these lines need to be removed to ensure the application of black to exercise 1 and 2 code is identical to exercise 3 code.